### PR TITLE
Add (re)enabling info dialog

### DIFF
--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -38,6 +38,7 @@
 #include "trayicon.h"
 #include "batteryhelper.h"
 #include "../config/powermanagementsettings.h"
+#include <LXQt/Notification>
 
 TrayIcon::TrayIcon(Solid::Battery *battery, QObject *parent)
     : QSystemTrayIcon(parent),
@@ -107,6 +108,15 @@ void TrayIcon::onAboutTriggered()
 
 void TrayIcon::onDisableIconTriggered()
 {
+    auto notification = new LXQt::Notification{tr("LXQt Power Management info"), nullptr};
+    notification->setBody(tr("The LXQt Power Management tray icon can be (re)enabled in <i>lxqt-config-powermanagement</i>"));
+    notification->setIcon("preferences-system-power-management");
+    notification->setActions({tr("Configure now")});
+    notification->setUrgencyHint(LXQt::Notification::UrgencyLow);
+    connect(notification, &LXQt::Notification::actionActivated, [notification] { notification->close(); QProcess::startDetached("lxqt-config-powermanagement"); });
+    connect(notification, &LXQt::Notification::notificationClosed, notification, &QObject::deleteLater);
+    notification->update();
+
     PowerManagementSettings().setShowIcon(false);
 }
 


### PR DESCRIPTION
Show information about reenabling after disabling the tray icon from tray menu.

closes lxde/lxqt#849