### PR TITLE
Fix source language in Italian translation file

### DIFF
--- a/config/translations/lxqt-config-powermanagement_it.ts
+++ b/config/translations/lxqt-config-powermanagement_it.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="it" sourcelanguage="it">
+<TS version="2.1" language="it">
 <context>
     <name>BatteryWatcherSettings</name>
     <message>


### PR DESCRIPTION
The file's source language was set to "it".

Thanks!