### PR TITLE
Don't lock the screen when it's already locked.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(lxqt-powermanagement)
 
+find_package(X11 REQUIRED QUIET)
+
 set(QTX_LIBRARIES Qt5::Widgets Qt5::DBus Qt5::Svg Qt5::X11Extras)
 
 set(SOURCES
@@ -118,6 +120,8 @@ target_link_libraries(lxqt-powermanagement
     ${XCB_SCREENSAVER_LIBRARY}
     ${XCB_DPMS_LIBRARY}
     ${X11_XCB_LIBRARY}
+    ${X11_Xscreensaver_LIB}
+    ${X11_X11_LIB}
     KF5::Solid
 )
 

--- a/src/watcher.cpp
+++ b/src/watcher.cpp
@@ -26,6 +26,7 @@
 #include <QDebug>
 #include "../config/powermanagementsettings.h"
 #include "watcher.h"
+#include "x11helper.h"
 
 Watcher::Watcher(QObject *parent) :
     QObject(parent),
@@ -41,7 +42,7 @@ Watcher::~Watcher()
 void Watcher::doAction(int action)
 {
     // if (action == -1) { }
-    if (action == -2)
+    if (action == -2 && !X11Helper::isScreenSaverLocked())
     {
         mScreenSaver.lockScreen();
         mLoop.exec();

--- a/src/x11helper.cpp
+++ b/src/x11helper.cpp
@@ -5,6 +5,8 @@
  * http://razor-qt.org
  *
  * Copyright (C) 2012  Alec Moskvin <alecm@gmx.com>
+ * Copyright (c) 2016  Luís Pereira <luis.artur.pereira@gmail.com>
+ * Copyright (c) 2012 The Chromium Authors. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -27,6 +29,70 @@
 #include <QtGui/QGuiApplication>
 #include <qpa/qplatformnativeinterface.h>
 
+#include <QX11Info>
+#include <X11/extensions/scrnsaver.h>
+
+
+static bool GetProperty(XID window, const std::string& property_name, long max_length,
+                 Atom* type, int* format, unsigned long* num_items,
+                 unsigned char** property);
+
+
+static bool GetIntArrayProperty(XID window,
+                         const std::string& property_name,
+                         std::vector<int>* value);
+
+
+static bool GetProperty(XID window, const std::string& property_name, long max_length,
+                 Atom* type, int* format, unsigned long* num_items,
+                 unsigned char** property)
+{
+    Atom property_atom =  XInternAtom(X11Helper::display(), property_name.c_str(), false);
+    unsigned long remaining_bytes = 0;
+    return XGetWindowProperty(QX11Info::display(),
+                              window,
+                              property_atom,
+                              0,          // offset into property data to read
+                              max_length, // max length to get
+                              False,      // deleted
+                              AnyPropertyType,
+                              type,
+                              format,
+                              num_items,
+                              &remaining_bytes,
+                              property);
+}
+
+static bool GetIntArrayProperty(XID window,
+                         const std::string& property_name,
+                         std::vector<int>* value)
+{
+    Atom type = None;
+    int format = 0;  // size in bits of each item in 'property'
+    unsigned long num_items = 0;
+    unsigned char* properties = NULL;
+
+    int result = GetProperty(window, property_name,
+                           (~0L), // (all of them)
+                           &type, &format, &num_items, &properties);
+    XScopedPtr<unsigned char> scoped_properties(properties);
+    if (result != Success)
+        return false;
+
+    if (format != 32)
+        return false;
+
+    long* int_properties = reinterpret_cast<long*>(properties);
+    value->clear();
+    for (unsigned long i = 0; i < num_items; ++i)
+    {
+        value->push_back(static_cast<int>(int_properties[i]));
+    }
+    return true;
+}
+
+
+
 Display* X11Helper::display()
 {
     QPlatformNativeInterface *native = qApp->platformNativeInterface();
@@ -39,4 +105,31 @@ xcb_connection_t* X11Helper::connection()
     QPlatformNativeInterface *native = qApp->platformNativeInterface();
     void* connection = native->nativeResourceForWindow("connection", 0);
     return reinterpret_cast<xcb_connection_t*>(connection);
+}
+
+bool X11Helper::isScreenSaverLocked()
+{
+    XScreenSaverInfo *info = 0;
+    info = XScreenSaverAllocInfo();
+
+    XScreenSaverQueryInfo(display(), DefaultRootWindow(display()), info);
+    const int state = info->state;
+    XFree(info);
+    if (state == ScreenSaverOn)
+        return true;
+
+    // Ironically, xscreensaver does not conform to the XScreenSaver protocol, so
+    // info.state == ScreenSaverOff or info.state == ScreenSaverDisabled does not
+    // necessarily mean that a screensaver is not active, so add a special check
+    // for xscreensaver.
+    XAtom lock_atom = XInternAtom(display(), "LOCK", false);
+    std::vector<int> atom_properties;
+    if (GetIntArrayProperty(DefaultRootWindow(display()), "_SCREENSAVER_STATUS", &atom_properties) &&
+        atom_properties.size() > 0)
+    {
+        if (atom_properties[0] == static_cast<int>(lock_atom))
+            return true;
+    }
+
+    return false;
 }

--- a/src/x11helper.h
+++ b/src/x11helper.h
@@ -5,6 +5,8 @@
  * http://razor-qt.org
  *
  * Copyright (C) 2013  Alec Moskvin <alecm@gmx.com>
+ * Copyright (c) 2016 Luís Pereira <luis.artur.pereira@gmail.com>
+ * Copyright (c) 2013 The Chromium Authors. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -25,10 +27,27 @@
 #ifndef X11HELPER_H
 #define X11HELPER_H
 
+#include <memory>
+
 #include <xcb/xcb.h>
 
 // Avoid polluting everything with X11/Xlib.h:
 typedef struct _XDisplay Display;
+
+typedef unsigned long XAtom;
+typedef unsigned long XID;
+
+extern "C" {
+int XFree(void*);
+}
+
+template <class T, class R, R (*F)(T*)>
+struct XObjectDeleter {
+  inline void operator()(void* ptr) const { F(static_cast<T*>(ptr)); }
+};
+
+template <class T, class D = XObjectDeleter<void, int, XFree>>
+using XScopedPtr = std::unique_ptr<T, D>;
 
 /**
  * @brief The X11Helper class is class to get the X11 Display or XCB connection
@@ -49,6 +68,8 @@ public:
      * @return
      */
     static xcb_connection_t* connection();
+
+    static bool isScreenSaverLocked();
 };
 
 #endif // X11HELPER_H


### PR DESCRIPTION
The status of the screensaver wasn't taken into account when locking it.
Now we only lock it if it's not already locked. This way we don't get the
annoying error message stating that there was an error starting the
screensaver.

Part of the code is taken from the Chromium project. Adapted to fit our
purposes.