### PR TITLE
Removes the QEventLoop from the Watcher class

### DIFF
--- a/src/watcher.cpp
+++ b/src/watcher.cpp
@@ -31,7 +31,6 @@ Watcher::Watcher(QObject *parent) :
     QObject(parent),
     mScreenSaver(this)
 {
-    connect(&mScreenSaver, SIGNAL(done()), &mLoop, SLOT(quit()));
 }
 
 Watcher::~Watcher()
@@ -44,7 +43,6 @@ void Watcher::doAction(int action)
     if (action == -2)
     {
         mScreenSaver.lockScreen();
-        mLoop.exec();
     }
     else if (action >= 0)
         mPower.doAction((LXQt::Power::Action) action);

--- a/src/watcher.h
+++ b/src/watcher.h
@@ -31,7 +31,6 @@ signals:
 private:
     LXQt::Power mPower;
     LXQt::ScreenSaver mScreenSaver;
-    QEventLoop mLoop;
 };
 
 #endif // WATCHER_H


### PR DESCRIPTION
We don't need to start a local event loop. The Idle watcher was the only
watcher "using" it. With the latest changes in screensaver control, it
actually messes everything. It prevents the Idle watcher to launch the
screensaver in some situations.