### PR TITLE
Drops Qt5Core_VERSION_STRING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(Qt5LinguistTools REQUIRED QUIET)
 find_package(Qt5Svg REQUIRED)
 find_package(Qt5Widgets REQUIRED)
 find_package(Qt5X11Extras REQUIRED)
-message(STATUS "Building with Qt${Qt5Core_VERSION_STRING}")
+message(STATUS "Building with Qt${Qt5Core_VERSION}")
 
 find_package(KF5Solid REQUIRED)
 


### PR DESCRIPTION
Use Qt5Core_VERSION. Qt5Core_VERSION_STRING is a compatibility variable and
it was removed in Qt 5.9 release.