### PR TITLE
Removed useless options

### DIFF
--- a/config/batterywatchersettings.cpp
+++ b/config/batterywatchersettings.cpp
@@ -54,7 +54,7 @@ BatteryWatcherSettings::BatteryWatcherSettings(QWidget *parent) :
 
 {
     mUi->setupUi(this);
-    fillComboBox(mUi->actionComboBox, true);
+    fillComboBox(mUi->actionComboBox, true, false , false);
     fillIconTypeCombo(mUi->iconTypeComboBox);
     mUi->chargeLevelSlider->setValue(53);
     mChargingIconProducer.updateState(Solid::Battery::Charging);

--- a/config/helpers.cpp
+++ b/config/helpers.cpp
@@ -29,7 +29,7 @@
 
 #include "helpers.h"
 
-void fillComboBox(QComboBox* comboBox, bool ask, bool monitor)
+void fillComboBox(QComboBox* comboBox, bool ask, bool monitor, bool lock)
 {
     comboBox->clear();
     comboBox->addItem(QObject::tr("Nothing"), -1);
@@ -37,7 +37,10 @@ void fillComboBox(QComboBox* comboBox, bool ask, bool monitor)
     {
         comboBox->addItem(QObject::tr("Ask"), LXQt::Power::PowerShowLeaveDialog);
     }
-    comboBox->addItem(QObject::tr("Lock screen"), -2); // FIXME
+    if (lock)
+    {
+        comboBox->addItem(QObject::tr("Lock screen"), -2); // FIXME
+    }
     comboBox->addItem(QObject::tr("Suspend"), LXQt::Power::PowerSuspend);
     comboBox->addItem(QObject::tr("Hibernate"), LXQt::Power::PowerHibernate);
     comboBox->addItem(QObject::tr("Shutdown"), LXQt::Power::PowerShutdown);

--- a/config/helpers.h
+++ b/config/helpers.h
@@ -10,7 +10,7 @@
 
 #include <QComboBox>
 
-void fillComboBox(QComboBox* comboBox, bool ask = false, bool monitor = true);
+void fillComboBox(QComboBox* comboBox, bool ask = false, bool monitor = true, bool lock = true);
 
 void setComboBoxToValue(QComboBox* comboBox, int value);
 


### PR DESCRIPTION
Don't show "Lock Screen" and "Turn off monitor(s)" in low battery combobox.