### PR TITLE
Disable battery settings with no battery

### DIFF
--- a/config/batterywatchersettings.cpp
+++ b/config/batterywatchersettings.cpp
@@ -30,6 +30,7 @@
 #include <QLabel>
 #include <QGroupBox>
 #include <Solid/Battery>
+#include <Solid/Device>
 
 #include "batterywatchersettings.h"
 #include "ui_batterywatchersettings.h"
@@ -85,6 +86,13 @@ BatteryWatcherSettings::~BatteryWatcherSettings()
 
 void BatteryWatcherSettings::loadSettings()
 {
+    const QList<Solid::Device> devices = Solid::Device::listFromType(Solid::DeviceInterface::Battery, QString());
+
+    if (devices.isEmpty())
+    {
+        mUi->groupBox->setEnabled(false);
+    }
+
     mUi->groupBox->setChecked(mSettings.isBatteryWatcherEnabled());
     setComboBoxToValue(mUi->actionComboBox, mSettings.getPowerLowAction());
     mUi->warningSpinBox->setValue(mSettings.getPowerLowWarningTime());

--- a/config/batterywatchersettings.cpp
+++ b/config/batterywatchersettings.cpp
@@ -87,8 +87,18 @@ BatteryWatcherSettings::~BatteryWatcherSettings()
 void BatteryWatcherSettings::loadSettings()
 {
     const QList<Solid::Device> devices = Solid::Device::listFromType(Solid::DeviceInterface::Battery, QString());
+    bool hasBattery = false;
 
-    if (devices.isEmpty())
+    for (const Solid::Device &device : devices)
+    {
+        if (device.as<Solid::Battery>()->type() == Solid::Battery::PrimaryBattery)
+        {
+            hasBattery = true;
+            break;
+        }
+    }
+
+    if (!hasBattery)
     {
         mUi->groupBox->setEnabled(false);
     }

--- a/config/idlenesswatchersettings.cpp
+++ b/config/idlenesswatchersettings.cpp
@@ -32,6 +32,7 @@
 #include "idlenesswatchersettings.h"
 #include "ui_idlenesswatchersettings.h"
 #include "helpers.h"
+#include <Solid/Device>
 
 IdlenessWatcherSettings::IdlenessWatcherSettings(QWidget *parent) :
     QWidget(parent),
@@ -100,8 +101,16 @@ IdlenessWatcherSettings::IdlenessWatcherSettings(QWidget *parent) :
     mUi->idleACMonitorLabel->setToolTip(tooltip);
     mUi->idleBatteryMonitorLabel->setToolTip(tooltip);
 
+    // Disable idle settings on battery without battery.
+    const QList<Solid::Device> devices = Solid::Device::listFromType(Solid::DeviceInterface::Battery, QString());
+
+    if (devices.isEmpty())
+    {
+        mUi->batteryGroupBox->setEnabled(false);
+    }
+
     mBacklight = new LXQt::Backlight(this);
-    // If if no backlight support then disable backlight control:
+    // If no backlight support then disable backlight control:
     if(! mBacklight->isBacklightAvailable()) {
         mUi->idlenessBacklightWatcherGroupBox->setEnabled(false);
         mUi->idlenessBacklightWatcherGroupBox->setChecked(false);

--- a/config/idlenesswatchersettings.cpp
+++ b/config/idlenesswatchersettings.cpp
@@ -103,8 +103,18 @@ IdlenessWatcherSettings::IdlenessWatcherSettings(QWidget *parent) :
 
     // Disable idle settings on battery without battery.
     const QList<Solid::Device> devices = Solid::Device::listFromType(Solid::DeviceInterface::Battery, QString());
+    bool hasBattery = false;
 
-    if (devices.isEmpty())
+    for (const Solid::Device &device : devices)
+    {
+        if (device.as<Solid::Battery>()->type() == Solid::Battery::PrimaryBattery)
+        {
+            hasBattery = true;
+            break;
+        }
+    }
+
+    if (!hasBattery)
     {
         mUi->batteryGroupBox->setEnabled(false);
     }

--- a/config/idlenesswatchersettings.cpp
+++ b/config/idlenesswatchersettings.cpp
@@ -32,6 +32,7 @@
 #include "idlenesswatchersettings.h"
 #include "ui_idlenesswatchersettings.h"
 #include "helpers.h"
+#include <Solid/Battery>
 #include <Solid/Device>
 
 IdlenessWatcherSettings::IdlenessWatcherSettings(QWidget *parent) :


### PR DESCRIPTION
This is a part mentioned here too:
https://github.com/lxqt/lxqt-powermanagement/pull/428

IMO we should finish this "Desktop mode" for LXQt 2.4 which enables idle pausing and  powerprofiles switching from systray.
@palinek?

Btw first I wanted to disable lid settings too but maybe some users use a laptop without its battery, no idea if we could check for lid presence.